### PR TITLE
Fix README extends keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $formattedEmail = DataFormatter::create('email')->format('  JohnDoe@Example.com 
 ```php
 use Deller\DataNormalizer\Factories\DataFormatterFactory;
 
-class CustomFormatter implements \Deller\DataNormalizer\DataFormatter
+class CustomFormatter extends \Deller\DataNormalizer\DataFormatter
 {
     public function format($data)
     {
@@ -95,7 +95,7 @@ echo $customFormatter->format('some data'); // Output: "Formatted: SOME DATA"
 ```php
 use Deller\DataNormalizer\Factories\DataNormalizerFactory;
 
-class CustomNormalizer implements \Deller\DataNormalizer\DataNormalizer
+class CustomNormalizer extends \Deller\DataNormalizer\DataNormalizer
 {
     public function normalize($data)
     {

--- a/src/Utils/PhoneFormatHelper.php
+++ b/src/Utils/PhoneFormatHelper.php
@@ -14,14 +14,20 @@ class PhoneFormatHelper
     ];
 
     /**
-     * Convert a string format (e.g. 'E164') to its corresponding libphonenumber constant.
+     * Convert a string or integer representation of a phone number format into
+     * its corresponding {@link PhoneNumberFormat} enum case. When an enum case
+     * is provided it will be returned unchanged.
      */
-    public static function resolveFormat(string|int $format): int
+    public static function resolveFormat(string|int|PhoneNumberFormat $format): PhoneNumberFormat
     {
-        if (is_string($format)) {
-            return self::$formatMap[$format] ?? PhoneNumberFormat::E164;
-        } else {
+        if ($format instanceof PhoneNumberFormat) {
             return $format;
         }
+
+        if (is_string($format)) {
+            return self::$formatMap[$format] ?? PhoneNumberFormat::E164;
+        }
+
+        return PhoneNumberFormat::from($format);
     }
 }


### PR DESCRIPTION
## Summary
- fix README to extend framework data classes
- adjust phone format helper to accept/return enum

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684c1b7afbb08320ab3b0632fb6e8564