### PR TITLE
Add alias for DataFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You can install the package via composer:
 
 ```bash
 composer require dominik-eller/laravel-data-normalizer
+composer dump-autoload
 ```
 
 You can publish the config file with:

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
                 "Deller\\DataNormalizer\\DataNormalizerServiceProvider"
             ],
             "aliases": {
-                "DataNormalizer": "Deller\\DataNormalizer\\Facades\\DataNormalizer"
+                "DataNormalizer": "Deller\\DataNormalizer\\Facades\\DataNormalizer",
+                "DataFormatter": "Deller\\DataNormalizer\\Facades\\DataFormatter"
             }
         }
     },


### PR DESCRIPTION
## Summary
- expose DataFormatter facade alias via composer.json
- note that `composer dump-autoload` should be run after installation

## Testing
- `composer dump-autoload`
- `composer test` *(fails: PhoneFormatHelper::resolveFormat return type issues)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b7eee748320a9a460ce931c238c