### PR TITLE
Handle phone formatting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ use Deller\DataNormalizer\Facades\DataFormatter;
 $formattedPhone = DataFormatter::create('phone')->format('+4915112345678', ['format' => 'INTERNATIONAL']);
 // $formattedPhone will be "+49 151 1234 5678"
 ```
+If parsing fails, the formatter logs the error and returns the original value.
 
 
 ### Normalize an email address

--- a/src/Formatters/Phone.php
+++ b/src/Formatters/Phone.php
@@ -4,6 +4,7 @@ namespace Deller\DataNormalizer\Formatters;
 
 use Deller\DataNormalizer\DataFormatter;
 use Deller\DataNormalizer\Utils\PhoneFormatHelper;
+use Illuminate\Support\Facades\Log;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
@@ -27,7 +28,9 @@ class Phone extends DataFormatter
                 return $phoneUtil->format($numberProto, $formatConstant);
             }
         } catch (NumberParseException $e) {
-            // Handle error
+            Log::warning('Error formatting phone number: '.$e->getMessage(), [
+                'exception' => $e,
+            ]);
         }
 
         return $value;

--- a/src/Utils/PhoneFormatHelper.php
+++ b/src/Utils/PhoneFormatHelper.php
@@ -16,12 +16,16 @@ class PhoneFormatHelper
     /**
      * Convert a string format (e.g. 'E164') to its corresponding libphonenumber constant.
      */
-    public static function resolveFormat(string|int $format): int
+    public static function resolveFormat(string|int|PhoneNumberFormat $format): PhoneNumberFormat
     {
         if (is_string($format)) {
             return self::$formatMap[$format] ?? PhoneNumberFormat::E164;
-        } else {
+        }
+
+        if ($format instanceof PhoneNumberFormat) {
             return $format;
         }
+
+        return PhoneNumberFormat::from($format);
     }
 }


### PR DESCRIPTION
## Summary
- log `NumberParseException` when phone formatting fails
- mention new logging behavior in README
- update `PhoneFormatHelper` to support enum input

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684c1b81b63c8320bb2ac9f4ac2f12a3