### PR TITLE
Fix PHPStan configuration

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,13 +1,2 @@
 parameters:
-	ignoreErrors:
-		-
-			message: '#^Parameter \#2 \$numberFormat of method libphonenumber\\PhoneNumberUtil\:\:format\(\) expects libphonenumber\\PhoneNumberFormat, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Formatters/Phone.php
-
-		-
-			message: '#^Parameter \#2 \$numberFormat of method libphonenumber\\PhoneNumberUtil\:\:format\(\) expects libphonenumber\\PhoneNumberFormat, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Normalizers/Phone.php
+    ignoreErrors: []


### PR DESCRIPTION
## Summary
- remove old ignore rules in `phpstan-baseline.neon`

## Testing
- `composer analyse`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_684c28a2cb0c832084fdc2da09ef2cfc